### PR TITLE
Adds `docs/` folder with starter documentation structure for GSoC.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# GSoC Documentation Index
+
+Welcome to the **OpenGov Africa GSoC Documentation Folder**.  
+This section contains guides and templates for mentors, students, and organization admins.
+
+## 📂 Available Guides
+- [Organization Application Guide](org-application.md)
+- [Program Ideas](program-ideas.md)
+- [Mentor Guidelines](mentor-guidelines.md)
+- [Student Guidelines](student-guidelines.md)
+- [Timeline & Milestones](timeline-milestones.md)
+- [Onboarding Materials](onboarding.md)
+- [Frequently Asked Questions](faq.md)
+
+> All documentation here is part of OpenGov Africa’s participation in **Google Summer of Code (GSoC)**.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,13 @@
+# Frequently Asked Questions
+
+**Q: Who can participate in GSoC?**  
+A: Any eligible student as defined by Google’s GSoC rules.
+
+**Q: What license does OpenGov Africa use?**  
+A: MIT License (check LICENSE file in the repo).
+
+**Q: How do I communicate with mentors?**  
+A: Use official Slack/Discord channels or GitHub Discussions.
+
+**Q: Where do I submit my proposal?**  
+A: Via the official GSoC platform when applications open.

--- a/docs/mentor-guidelines.md
+++ b/docs/mentor-guidelines.md
@@ -1,0 +1,20 @@
+# Mentor Guidelines
+
+## Roles and Responsibilities
+- Guide students through project development.
+- Review code and provide constructive feedback.
+- Attend weekly or biweekly sync meetings.
+- Approve mid-term and final evaluations.
+
+## Expectations
+- Be responsive on communication channels.
+- Help students learn open-source best practices.
+- Encourage independent problem-solving.
+
+## Reporting
+Mentors should post short weekly updates summarizing student progress.
+
+## Best Practices
+- Use clear, actionable feedback.
+- Maintain documentation for each project.
+- Promote a healthy, inclusive learning environment.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,16 @@
+# Onboarding Materials
+
+## For New Contributors
+1. Fork the repository.
+2. Clone it locally.
+3. Create a new branch for your contribution.
+4. Follow the Contributor Guide *(coming soon)* once it’s published in the repository.
+
+## Getting Started
+- Review project READMEs to understand structure.
+- Join the communication channels (Slack/Discord).
+- Make your first small PR (docs or typo fix).
+
+## For Mentors
+- Review this onboarding material with new students.
+- Help them set up and test the project environment.

--- a/docs/org-application.md
+++ b/docs/org-application.md
@@ -1,0 +1,23 @@
+# Organization Application Guide
+
+## Purpose
+This document helps OpenGov Africa prepare its **GSoC organization application**.
+
+## Overview
+OpenGov Africa focuses on:
+- Civic technology and open data
+- Transparency and digital inclusion
+- Collaborative open-source initiatives in Africa
+
+## Requirements
+- Active open-source projects
+- At least two experienced mentors
+- A list of project ideas with difficulty levels
+
+## Steps to Apply
+1. Review the official GSoC org eligibility criteria.
+2. Collect required info (organization details, past contributions, mentor bios).
+3. Submit the application before the GSoC org deadline.
+
+## Notes
+Keep this document updated each year when GSoC opens applications.

--- a/docs/program-ideas.md
+++ b/docs/program-ideas.md
@@ -1,0 +1,19 @@
+# GSoC Program Ideas
+
+This page lists potential project ideas for GSoC students under OpenGov Africa.
+
+---
+
+### 🧩 Example Idea 1 – Open Civic Data Dashboard
+**Description:** Build a web dashboard to visualize civic datasets.  
+**Tech stack:** React, Node.js, D3.js  
+**Expected outcome:** Interactive charts showing government transparency metrics.  
+**Difficulty:** Medium  
+**Mentors:** To be assigned
+
+---
+
+### 🧩 Example Idea 2 – Documentation Automation Tool
+**Description:** Script to automate generation of reports and documentation pages.  
+**Tech stack:** Python, Markdown, GitHub Actions  
+**Expected outcome:** Auto-updated docs with community metrics.

--- a/docs/student-guidelines.md
+++ b/docs/student-guidelines.md
@@ -1,0 +1,19 @@
+# Student Guidelines
+
+## Eligibility
+Follow [Google’s official GSoC eligibility rules](https://summerofcode.withgoogle.com/).
+
+## How to Apply
+1. Choose a project idea from the Program Ideas page.
+2. Contact potential mentors early.
+3. Submit a well-written proposal before the deadline.
+
+## Expectations
+- Communicate regularly with mentors.
+- Commit code frequently (small, meaningful PRs).
+- Submit progress reports as required.
+
+## Helpful Resources
+- [Student-template](../student-template.md) 
+- **Contributor Guide** (to be added soon — see repo updates)
+- GitHub Discussions / Discord for community chat

--- a/docs/timeline-milestones.md
+++ b/docs/timeline-milestones.md
@@ -1,0 +1,12 @@
+# GSoC Timeline & Milestones
+
+| Phase | Description | Tentative Date |
+|-------|--------------|----------------|
+| Organization Applications | OpenGov Africa submits org profile | TBA |
+| Student Application Period | Students submit proposals | TBA |
+| Community Bonding | Students meet mentors & learn | TBA |
+| Coding Phase | Main development work | TBA |
+| Mid-Term Evaluation | Progress check | TBA |
+| Final Evaluation | Project wrap-up | TBA |
+
+> Update this file each GSoC cycle with actual Google-provided dates.


### PR DESCRIPTION
Fixes #4 
Related Issue : [OpenGovAfrica/hacktoberfest#17](https://github.com/OpenGovAfrica/hacktoberfest/issues/17)

**Includes:**
- README with index
- Org application guide
- Program ideas
- Mentor & Student guidelines
- Timeline
- Onboarding
- FAQ

Closes #4 