### PR TITLE
Updated table in docs/project-ideas to make links clickable

### DIFF
--- a/docs/project-ideas.md
+++ b/docs/project-ideas.md
@@ -2,14 +2,14 @@
 
 OpenGov Africa is preparing to apply as a **Google Summer of Code (GSoC) 2026 Mentoring Organization**.
 
-This page presents a curated set of **mission-aligned, Africa-first proposed project ideas** that reflect OpenGov Africa’s core mandate:  
+This page presents a curated set of **mission-aligned, Africa-first proposed project ideas** that reflect OpenGov Africa’s core mandate:
 **leveraging open data, open-source technologies, and civic innovation to strengthen transparency, accountability, and citizen participation across African governance systems.**
 
 These ideas are intentionally grounded in **real political, social, and institutional realities on the continent**—from elections and public finance to civic space, protests, and digital rights.
 
 Project ideas may evolve based on mentor input, contributor feedback, and feasibility discussions. Community members interested in mentoring are encouraged to propose refinements or entirely new ideas aligned with our mission.
 
-The table below outlines **proposed GSoC 2026 project ideas** for OpenGov Africa.  
+The table below outlines **proposed GSoC 2026 project ideas** for OpenGov Africa.
 All projects are aligned with our mission to advance **open governance, transparency, accountability, civic participation, and digital rights across Africa**.
 
 ---
@@ -20,30 +20,30 @@ These projects have a clearly defined scope and are suitable for a standard 12 w
 
 | Project Title | Category | Skills to Study / Improve | Short Description | Expected Outcomes / Deliverables (Final Done = Tool Usable) | Code Repository | Mentor(s) |
 |--------------|----------|----------------------------|-------------------|--------------------------------------------------------------|-----------------|-----------|
-| OGA Public Office Register (Citizens-in-Office Tracker) | Governance & Accountability | Web Development, Databases, Data Modeling, Research Automation | Build a transparent, verifiable system documenting public officials, offices held, tenure, and affiliations using open data, with strong provenance and data ethics. | • Application can be deployed by a new contributor using documented steps <br> • At least one African country’s public office data is fully ingested and browseable <br> • Users can view public officials, offices held, tenure dates, and affiliations end-to-end <br> • Every data point includes a clear source and audit trail <br> • Public read-only API endpoints return documented, valid responses <br> • Data model conforms to Popolo (Person, Organization, Post, Membership) <br> • Verified vs unverified data is clearly distinguished <br> • Core functionality is covered by basic automated tests <br> • Documentation explains data sources, limitations, and update workflow | github.com/OpenGovAfrica/oga-public-office-register | Tamara, & Bena - gsoc@opengovafrica.org |
-| OGA Budget Lens (AI-Assisted Budget Document Parsing) | GovTech / AI | Python, NLP, Document Processing | Design an AI-assisted pipeline to extract, structure, and analyze data from complex and often unstructured African government budget documents. | • A user can run the full pipeline on a new budget PDF using documented commands <br> • OCR and extraction work on at least one real African budget document end-to-end <br> • Structured outputs are produced in machine-readable formats (CSV, JSON) <br> • The system does not fabricate amounts or line items beyond source documents <br> • A human-in-the-loop review interface allows correction and approval of extracted data <br> • Evaluation metrics (accuracy, completeness) are reported on sample documents <br> • Known limitations and failure modes are clearly documented <br> • Outputs are reusable by external analysis tools and researchers | github.com/OpenGovAfrica/oga-budget-lens | Tamara, & Bena - gsoc@opengovafrica.org  |
-| OGA Local Service Atlas (Local Government Service Delivery Tracker) | Service Delivery / Civic Tech | Web Development, Databases, Data Collection | Create a platform to track local government service delivery (water, sanitation, health, education) using open datasets and community-reported inputs. | • Platform can be deployed by a new user using documented steps <br> • At least one locality is populated with real service delivery data <br> • Users can browse, search, and view services (e.g. health facilities, water points) <br> • An interactive map or dashboard accurately reflects stored data <br> • New data can be added through a documented ingestion or submission process <br> • Basic validation prevents clearly invalid or incomplete records <br> • Data sources and update cadence are clearly shown to users <br> • Contributor and user documentation enables ongoing maintenance | github.com/OpenGovAfrica/oga-local-service-atlas | Tamara & Bena - gsoc@opengovafrica.org |
+| OGA Public Office Register (Citizens-in-Office Tracker) | Governance & Accountability | Web Development, Databases, Data Modeling, Research Automation | Build a transparent, verifiable system documenting public officials, offices held, tenure, and affiliations using open data, with strong provenance and data ethics. | • Application can be deployed by a new contributor using documented steps <br> • At least one African country’s public office data is fully ingested and browseable <br> • Users can view public officials, offices held, tenure dates, and affiliations end-to-end <br> • Every data point includes a clear source and audit trail <br> • Public read-only API endpoints return documented, valid responses <br> • Data model conforms to Popolo (Person, Organization, Post, Membership) <br> • Verified vs unverified data is clearly distinguished <br> • Core functionality is covered by basic automated tests <br> • Documentation explains data sources, limitations, and update workflow | [Project Repo](github.com/OpenGovAfrica/oga-public-office-register) | Tamara, & Bena - gsoc@opengovafrica.org |
+| OGA Budget Lens (AI-Assisted Budget Document Parsing) | GovTech / AI | Python, NLP, Document Processing | Design an AI-assisted pipeline to extract, structure, and analyze data from complex and often unstructured African government budget documents. | • A user can run the full pipeline on a new budget PDF using documented commands <br> • OCR and extraction work on at least one real African budget document end-to-end <br> • Structured outputs are produced in machine-readable formats (CSV, JSON) <br> • The system does not fabricate amounts or line items beyond source documents <br> • A human-in-the-loop review interface allows correction and approval of extracted data <br> • Evaluation metrics (accuracy, completeness) are reported on sample documents <br> • Known limitations and failure modes are clearly documented <br> • Outputs are reusable by external analysis tools and researchers | [Project Repo](github.com/OpenGovAfrica/oga-budget-lens) | Tamara, & Bena - gsoc@opengovafrica.org  |
+| OGA Local Service Atlas (Local Government Service Delivery Tracker) | Service Delivery / Civic Tech | Web Development, Databases, Data Collection | Create a platform to track local government service delivery (water, sanitation, health, education) using open datasets and community-reported inputs. | • Platform can be deployed by a new user using documented steps <br> • At least one locality is populated with real service delivery data <br> • Users can browse, search, and view services (e.g. health facilities, water points) <br> • An interactive map or dashboard accurately reflects stored data <br> • New data can be added through a documented ingestion or submission process <br> • Basic validation prevents clearly invalid or incomplete records <br> • Data sources and update cadence are clearly shown to users <br> • Contributor and user documentation enables ongoing maintenance | [Project Repo](github.com/OpenGovAfrica/oga-local-service-atlas) | Tamara & Bena - gsoc@opengovafrica.org |
 
 ---
 
-## Draft Project Ideas 
+## Draft Project Ideas
 
 These ideas are accepted in principle but may evolve in scope. Contributors and mentors are encouraged to participate in discussions.
 
 ### 🧩 Example Idea 1 – Open Civic Data Dashboard
-**Description:** Build a web dashboard to visualize civic datasets.  
-**Tech stack:** React, Node.js, D3.js  
-**Expected outcome:** Interactive charts showing government transparency metrics.  
-**Difficulty:** Medium  
+**Description:** Build a web dashboard to visualize civic datasets.
+**Tech stack:** React, Node.js, D3.js
+**Expected outcome:** Interactive charts showing government transparency metrics.
+**Difficulty:** Medium
 **Mentors:** To be assigned
 
 ---
 
 ### 🧩 Example Idea 2 – Documentation Automation Tool
-**Description:** Script to automate generation of reports and documentation pages.  
-**Tech stack:** Python, Markdown, GitHub Actions  
+**Description:** Script to automate generation of reports and documentation pages.
+**Tech stack:** Python, Markdown, GitHub Actions
 **Expected outcome:** Auto-updated docs with community metrics.
-**Difficulty:** Medium  
+**Difficulty:** Medium
 **Mentors:** To be assigned
 
 ---
@@ -75,37 +75,37 @@ These ideas are accepted in principle but may evolve in scope. Contributors and 
 ## Proposing New Project Ideas
 
 Community members and potential mentors are welcome to propose new ideas that:
-- Align with OpenGov Africa’s mission  
-- Address real governance or accountability gaps  
-- Can be executed within a GSoC timeframe  
-- Are ethically grounded and politically aware  
+- Align with OpenGov Africa’s mission
+- Address real governance or accountability gaps
+- Can be executed within a GSoC timeframe
+- Are ethically grounded and politically aware
 
 Project proposals should include:
-- Problem statement  
-- Expected deliverables  
-- Required skills  
-- Mentorship availability  
+- Problem statement
+- Expected deliverables
+- Required skills
+- Mentorship availability
 
 ---
 
 ## Mentorship at OpenGov Africa
 
 We value mentors who:
-- Understand African political and civic realities  
-- Are committed to ethical open-source development  
-- Can guide contributors beyond just code, into context and impact  
+- Understand African political and civic realities
+- Are committed to ethical open-source development
+- Can guide contributors beyond just code, into context and impact
 
 You do not need to be a “perfect” expert—commitment, clarity, and context-awareness matter more.
 
 ## Next Steps
 
-- Interested mentors should signal interest and propose project ideas 
-- Contributors are encouraged to engage early with discussions and starter tasks  
-- Final project list will be published as part of our GSoC application  
+- Interested mentors should signal interest and propose project ideas
+- Contributors are encouraged to engage early with discussions and starter tasks
+- Final project list will be published as part of our GSoC application
 
-OpenGov Africa is building **for citizens, by citizens, with open technology**.  
+OpenGov Africa is building **for citizens, by citizens, with open technology**.
 If this resonates with you, we invite you to help shape what comes next.
 
 
-**Note:**  
+**Note:**
 All projects are subject to refinement based on mentor availability, feasibility within the GSoC timeline, and community feedback. OpenGov Africa prioritizes ethical development, political context awareness, and citizen impact.


### PR DESCRIPTION
### **PR Description Template**
**Title: docs: convert plain text URLs to clickable markdown links**

**Description:**
This PR improves the readability and navigation of the project ideas section. I have converted plain text repository URLs into descriptive Markdown links.

Changes:

- Updated the accepted project ideas repo links to use clickable inline links.
- Improved scannability by using descriptive link titles instead of raw URLs.

**Why this is important:**
Navigating the project list is now more efficient for potential contributors, allowing them to jump directly to the relevant repositories or documentation without manual copy-pasting.
